### PR TITLE
PopulateMergeWhen should add ID to fixture stack

### DIFF
--- a/code/PopulateFactory.php
+++ b/code/PopulateFactory.php
@@ -104,7 +104,7 @@ class PopulateFactory extends FixtureFactory {
 
 			$obj->delete();
 			
-			$this->fixtures[$class][$identifier] = $existing; 
+			$this->fixtures[$class][$identifier] = $existing->ID;
 
 			$obj = $existing;
 			$obj->flushCache();


### PR DESCRIPTION
All other occurrences that create objects only save the objects ID to FixtureFactory->fixtures, the PopulateMergeWhen handler added the object instead, causing an error "can nott convert object to int" when being used to set relationships.