### PR TITLE
Ability to truncate non-DataObject tables

### DIFF
--- a/code/Populate.php
+++ b/code/Populate.php
@@ -75,7 +75,7 @@ class Populate extends Object {
 				self::truncate_versions($objName, $versions);
 			}
 
-			foreach(ClassInfo::getValidSubClasses($objName) as $table) {
+			foreach((array)ClassInfo::getValidSubClasses($objName) as $table) {
 				self::truncate_table($table);
 				self::truncate_versions($table, $versions);
 			}


### PR DESCRIPTION
fixes

[Warning] Invalid argument supplied for foreach()

when trying to truncate SiteTree_translationgroups table (which is no DataObject table)