### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
             "email": "will.rossiter@dna.co.nz"
     }],
     "require": {
-            "silverstripe/framework": ">=3.1.3"
+            "silverstripe/framework": "^3.1.3"
     },
     "extra": {
       "installer-name": "populate"


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.