### PR TITLE
FEAT: Allow one level of circular dependency resolution

### DIFF
--- a/code/Populate.php
+++ b/code/Populate.php
@@ -61,7 +61,8 @@ class Populate
 			throw new \Exception('requireRecords can only be run in development or test environments');
 		}
 
-		$factory = Injector::inst()->create('DNADesign\Populate\PopulateFactory');
+		/** @var PopulateFactory $factory */
+		$factory = Injector::inst()->create(PopulateFactory::class);
 
 		foreach(self::config()->get('truncate_objects') as $objName) {
 			$versions = array();
@@ -99,6 +100,7 @@ class Populate
 		}
 
 		foreach(self::config()->get('include_yaml_fixtures') as $fixtureFile) {
+			DB::alteration_message(sprintf('Processing %s', $fixtureFile), 'created');
 			$fixture = new YamlFixture($fixtureFile);
 			$fixture->writeInto($factory);
 
@@ -114,6 +116,9 @@ class Populate
 		} else {
 			$populate = $this;
 		}
+
+		DB::alteration_message("Processing failed fixtures", "created");
+		$factory->processFailedFixtures();
 
 		$populate->extend('onAfterPopulateRecords');
 

--- a/code/PopulateFactory.php
+++ b/code/PopulateFactory.php
@@ -3,6 +3,7 @@
 namespace DNADesign\Populate;
 
 use Exception;
+use InvalidArgumentException;
 use phpDocumentor\Reflection\DocBlock\Tags\Version;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
@@ -19,6 +20,13 @@ use SilverStripe\Versioned\Versioned;
  * @package populate
  */
 class PopulateFactory extends FixtureFactory {
+	/**
+	 * List of fixtures that failed to be created due to YAML fixture lookup failures (e.g. because of a dependency that
+	 * isn't met at the time of creation). We re-try creation of these after all other fixtures have been created.
+	 *
+	 * @var array
+	 */
+	private $failedFixtures = [];
 
 	/**
 	 * Creates the object in the database as the original object will be wiped.
@@ -168,7 +176,22 @@ class PopulateFactory extends FixtureFactory {
 			$obj->flushCache();
 		}
 		else {
-			$obj = parent::createObject($class, $identifier, $data);
+			try {
+				$obj = parent::createObject($class, $identifier, $data);
+			} catch (InvalidArgumentException $e) {
+				$this->failedFixtures[] = [
+					'class' => $class,
+					'id' => $identifier,
+					'data' => $data
+				];
+
+				DB::alteration_message(
+					sprintf('Failed to create %s (%s), queueing for later', $identifier, $class),
+					'error'
+				);
+
+				return null;
+			}
 		}
 
 		if($obj->hasExtension(Versioned::class)) {
@@ -184,5 +207,22 @@ class PopulateFactory extends FixtureFactory {
 		}
 
 		return $obj;
+	}
+
+	public function processFailedFixtures()
+	{
+		if ($this->failedFixtures) {
+			foreach ($this->failedFixtures as $fixture) {
+				// createObject returns null if the object failed to create
+				$obj = $this->createObject($fixture['class'], $fixture['id'], $fixture['data']);
+
+				if (is_null($obj)) {
+					DB::alteration_message(
+						sprintf('Final attempt to create %s (%s) still failed', $fixture['id'], $fixture['class']),
+						'error'
+					);
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
This is where one fixture refers to another that hasn't been defined yet.

For example, previously the following code wouldn't work. After this patch, it will correctly build the two fixtures:

```yaml
Page:
  page1:
    Title: Page 1
    ParentID: =>Page.page2
  page2:
    Title: Page 2
    LinkedPageID: =>Page.page1
```