### PR TITLE
Update Readme for PHP operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ current scope of the importer.
 
 	Page:
 	  mythankyoupage:
-	    ThankYouText: `Page::config()->thank_you_text`;
-	    LinkedPage: `sprintf("[Page](%s)", HelpPage::get()->first()->Link())`;
+	    ThankYouText: "`Page::config()->thank_you_text`;"
+	    LinkedPage: "`sprintf(\"[Page](%s)\", App\\Page\\HelpPage::get()->first()->Link())`;"
 
 ### Updating Records
 


### PR DESCRIPTION
The backtick approach in yml does not work unless wrapped in double quotes.
Also added an example of a namespaced class as its useful to note the backslashes should be escaped.