### PR TITLE
Remove use of deprecated publish method. Plus linting fixes

### DIFF
--- a/code/Populate.php
+++ b/code/Populate.php
@@ -20,130 +20,135 @@ class Populate
     use Configurable;
     use Extensible;
 
-	/**
-	 * @config
-	 *
-	 * @var array
-	 */
-	private static $include_yaml_fixtures = array();
+    /**
+     * @config
+     *
+     * @var array
+     */
+    private static $include_yaml_fixtures = array();
 
-	/**
-	 * @config
-	 *
-	 * An array of classes to clear from the database before importing. While
-	 * populating sitetree it may be worth clearing the 'SiteTree' table.
-	 *
-	 * @var array
-	 */
-	private static $truncate_objects = array();
+    /**
+     * @config
+     *
+     * An array of classes to clear from the database before importing. While
+     * populating sitetree it may be worth clearing the 'SiteTree' table.
+     *
+     * @var array
+     */
+    private static $truncate_objects = array();
 
-	/**
-	 * Flag to determine if we're already run for this session (i.e to prevent
-	 * parent calls invoking {@link requireRecords} twice).
-	 *
-	 * @var bool
-	 */
-	private static $ran = false;
+    /**
+     * Flag to determine if we're already run for this session (i.e to prevent
+     * parent calls invoking {@link requireRecords} twice).
+     *
+     * @var bool
+     */
+    private static $ran = false;
 
-	/**
-	 * @var bool
-	 *
-	 * @throws Exception
-	 */
-	public static function requireRecords($force = false) {
-		if(self::$ran && !$force) {
-			return true;
-		}
+    /**
+     * @throws Exception
+     * @var bool
+     *
+     */
+    public static function requireRecords($force = false)
+    {
+        if (self::$ran && !$force) {
+            return true;
+        }
 
-		self::$ran = true;
+        self::$ran = true;
 
-		if(!(Director::isDev() || Director::isTest())) {
-			throw new \Exception('requireRecords can only be run in development or test environments');
-		}
+        if (!(Director::isDev() || Director::isTest())) {
+            throw new \Exception('requireRecords can only be run in development or test environments');
+        }
 
-		$factory = Injector::inst()->create('DNADesign\Populate\PopulateFactory');
+        $factory = Injector::inst()->create('DNADesign\Populate\PopulateFactory');
 
-		foreach(self::config()->get('truncate_objects') as $objName) {
-			$versions = array();
+        foreach (self::config()->get('truncate_objects') as $objName) {
+            $versions = array();
 
-			if(class_exists($objName)) {
-				foreach(DataList::create($objName) as $obj) {
-					// if the object has the versioned extension, make sure we delete
-					// that as well
-					if($obj->hasExtension('SilverStripe\Versioned\Versioned')) {
-						foreach($obj->getVersionedStages() as $stage) {
-							$versions[$stage] = true;
+            if (class_exists($objName)) {
+                foreach (DataList::create($objName) as $obj) {
+                    // if the object has the versioned extension, make sure we delete
+                    // that as well
+                    if ($obj->hasExtension('SilverStripe\Versioned\Versioned')) {
+                        foreach ($obj->getVersionedStages() as $stage) {
+                            $versions[$stage] = true;
 
-							$obj->deleteFromStage($stage);
-						}
-					}
+                            $obj->deleteFromStage($stage);
+                        }
+                    }
 
-					try {
-						@$obj->delete();
-					} catch(\Exception $e) {
-						// notice
-					}
-				}
-			}
+                    try {
+                        @$obj->delete();
+                    } catch (\Exception $e) {
+                        // notice
+                    }
+                }
+            }
 
-			if($versions) {
-				self::truncate_versions($objName, $versions);
-			}
+            if ($versions) {
+                self::truncate_versions($objName, $versions);
+            }
 
-			foreach((array)ClassInfo::dataClassesFor($objName) as $table) {
-				self::truncate_table($table);
-				self::truncate_versions($table, $versions);
-			}
+            foreach ((array)ClassInfo::dataClassesFor($objName) as $table) {
+                self::truncate_table($table);
+                self::truncate_versions($table, $versions);
+            }
 
-			self::truncate_table($objName);
-		}
+            self::truncate_table($objName);
+        }
 
-		foreach(self::config()->get('include_yaml_fixtures') as $fixtureFile) {
-			$fixture = new YamlFixture($fixtureFile);
-			$fixture->writeInto($factory);
+        foreach (self::config()->get('include_yaml_fixtures') as $fixtureFile) {
+            $fixture = new YamlFixture($fixtureFile);
+            $fixture->writeInto($factory);
 
-			$fixture = null;
-		}
+            $fixture = null;
+        }
 
-		// hook allowing extensions to clean up records, modify the result or
-		// export the data to a SQL file (for importing performance).
-		$static = !(isset($this) && get_class($this) == __CLASS__);
+        // hook allowing extensions to clean up records, modify the result or
+        // export the data to a SQL file (for importing performance).
+        $static = !(isset($this) && get_class($this) == __CLASS__);
 
-		if($static) {
-			$populate = Injector::inst()->create(Populate::class);
-		} else {
-			$populate = $this;
-		}
+        if ($static) {
+            $populate = Injector::inst()->create(Populate::class);
+        } else {
+            $populate = $this;
+        }
 
-		$populate->extend('onAfterPopulateRecords');
+        $populate->extend('onAfterPopulateRecords');
 
-		return true;
-	}
+        return true;
+    }
 
-	private static function truncate_table($class) {
+    private static function truncate_table($class)
+    {
         /** @var DataObjectSchema $schema */
-	    $schema = Injector::inst()->get(DataObjectSchema::class);
+        $schema = Injector::inst()->get(DataObjectSchema::class);
         $split = explode('_', $class);
         $table = $schema->tableName($split[0]);
 
-        if(!empty($split[1])) $table = sprintf('%s_%s', $table, $split[1]); // Re-add '_versions' etc.
+        if (!empty($split[1])) {
+            $table = sprintf('%s_%s', $table, $split[1]);
+        } // Re-add '_versions' etc.
 
-	    DB::alteration_message("Truncating table $table", "deleted");
+        DB::alteration_message("Truncating table $table", "deleted");
 
-		if(ClassInfo::hasTable($table)) {
-			if(method_exists(DB::get_conn(), 'clearTable')) {
-				DB::get_conn()->clearTable($table);
-			} else {
-				DB::query("TRUNCATE \"$table\"");
-			}
-		}
-	}
+        if (ClassInfo::hasTable($table)) {
+            if (method_exists(DB::get_conn(), 'clearTable')) {
+                DB::get_conn()->clearTable($table);
+            } else {
+                DB::query("TRUNCATE \"$table\"");
+            }
+        }
+    }
 
-	private static function truncate_versions($table, $versions) {
-		self::truncate_table($table .'_Versions');
+    private static function truncate_versions($table, $versions)
+    {
+        self::truncate_table($table . '_Versions');
 
-		foreach($versions as $stage => $v) {
-			self::truncate_table($table . '_'. $stage);
-		}
-	}
+        foreach ($versions as $stage => $v) {
+            self::truncate_table($table . '_' . $stage);
+        }
+    }
 }

--- a/tests/php/PopulateFactoryTest.php
+++ b/tests/php/PopulateFactoryTest.php
@@ -9,25 +9,25 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\Versioned\Versioned;
 
-
 /**
  * @package populate
  */
-class PopulateFactoryTest extends SapphireTest implements TestOnly {
+class PopulateFactoryTest extends SapphireTest implements TestOnly
+{
 
     /**
      * @var PopulateFactory
      */
-	private $factory;
+    private $factory;
 
     protected static $fixture_file = "PopulateFactoryTest.yml";
 
     protected $usesDatabase = true;
 
     protected static $extra_dataobjects = array(
-		PopulateFactoryTestObject::class,
+        PopulateFactoryTestObject::class,
         PopulateFactoryTestVersionedObject::class
-	);
+    );
 
     public function setUp()
     {
@@ -35,102 +35,106 @@ class PopulateFactoryTest extends SapphireTest implements TestOnly {
         $this->factory = new PopulateFactory();
     }
 
-	/**
-	 * Test version support. If an object has versioned then both the live and
-	 * staging tables should be updated. Other live records should be removed
-	 * as well.
-	 */
-	public function testVersionedObjects() {
-		$versioned = $this->objFromFixture(PopulateFactoryTestVersionedObject::class, 'objV1');
+    /**
+     * Test version support. If an object has versioned then both the live and
+     * staging tables should be updated. Other live records should be removed
+     * as well.
+     */
+    public function testVersionedObjects()
+    {
+        $versioned = $this->objFromFixture(PopulateFactoryTestVersionedObject::class, 'objV1');
 
-		$versioned->publish('Stage', 'Live');
+        $versioned->publish('Stage', 'Live');
 
-		$obj = $this->factory->createObject(PopulateFactoryTestVersionedObject::class, 'test', array(
-			'Content' => 'Updated Version Foo',
-			'PopulateMergeWhen' => "Title = 'Version Foo'"
-		));
+        $obj = $this->factory->createObject(PopulateFactoryTestVersionedObject::class, 'test', array(
+            'Content' => 'Updated Version Foo',
+            'PopulateMergeWhen' => "Title = 'Version Foo'"
+        ));
 
-		$this->assertEquals($versioned->ID, $obj->ID);
-		$this->assertEquals('Updated Version Foo', $obj->Content);
+        $this->assertEquals($versioned->ID, $obj->ID);
+        $this->assertEquals('Updated Version Foo', $obj->Content);
 
-		$check = Versioned::get_one_by_stage(
-			PopulateFactoryTestVersionedObject::class,
-			'Live',
-			"Title = 'Version Foo'"
-		);
+        $check = Versioned::get_one_by_stage(
+            PopulateFactoryTestVersionedObject::class,
+            'Live',
+            "Title = 'Version Foo'"
+        );
 
-		$this->assertEquals('Updated Version Foo', $check->Content);
-	}
+        $this->assertEquals('Updated Version Foo', $check->Content);
+    }
 
-	/**
-	 * As a utility you can include code to be evaluated the the yaml using
-	 * Field: `something::foo()`;
-	 */
-	public function testCreateObjectPhpEval() {
-		$obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
-			'Title' => '`sprintf("hi")`;'
-		));
+    /**
+     * As a utility you can include code to be evaluated the the yaml using
+     * Field: `something::foo()`;
+     */
+    public function testCreateObjectPhpEval()
+    {
+        $obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
+            'Title' => '`sprintf("hi")`;'
+        ));
 
-		$this->assertEquals('hi', $obj->Title);
-	}
+        $this->assertEquals('hi', $obj->Title);
+    }
 
-	/**
-	 * When a populatemergewhen clause is supplied, make sure it merges. If no
-	 * record found, one should be created
-	 *
-	 */
-	public function testCreateObjectPopulateMergeWhen() {
-		$obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
-			'Title' => 'Updated',
-			'PopulateMergeWhen' => "Title = 'Foo'"
-		));
+    /**
+     * When a populatemergewhen clause is supplied, make sure it merges. If no
+     * record found, one should be created
+     *
+     */
+    public function testCreateObjectPopulateMergeWhen()
+    {
+        $obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
+            'Title' => 'Updated',
+            'PopulateMergeWhen' => "Title = 'Foo'"
+        ));
 
-		$this->assertEquals('Foo Content', $obj->Content, 'Records merged');
+        $this->assertEquals('Foo Content', $obj->Content, 'Records merged');
 
-		$obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
-			'Title' => 'Updated',
-			'PopulateMergeWhen' => "Title = 'This title is unknown'"
-		));
+        $obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
+            'Title' => 'Updated',
+            'PopulateMergeWhen' => "Title = 'This title is unknown'"
+        ));
 
-		$this->assertGreaterThan(0, $obj->ID);
-		$this->assertEquals('Updated', $obj->Title);
-	}
+        $this->assertGreaterThan(0, $obj->ID);
+        $this->assertEquals('Updated', $obj->Title);
+    }
 
-	/**
-	 * When populatemergematch is provided then the matching should be done on
-	 * the given fields
-	 */
-	public function testCreateObjectPopulateMergeMatch() {
-		$id = PopulateFactoryTestObject::get()->filter(array(
-			'Title' => 'Foo'
-		))->first()->ID;
+    /**
+     * When populatemergematch is provided then the matching should be done on
+     * the given fields
+     */
+    public function testCreateObjectPopulateMergeMatch()
+    {
+        $id = PopulateFactoryTestObject::get()->filter(array(
+            'Title' => 'Foo'
+        ))->first()->ID;
 
-		$obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
-			'Title' => 'Foo',
-			'Content' => 'This has been replaced',
-			'PopulateMergeMatch' => array(
-				'Title'
-			)
-		));
+        $obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
+            'Title' => 'Foo',
+            'Content' => 'This has been replaced',
+            'PopulateMergeMatch' => array(
+                'Title'
+            )
+        ));
 
-		$this->assertEquals($id, $obj->ID, 'ID value has not changed');
-		$this->assertEquals('This has been replaced', $obj->Content);
-	}
+        $this->assertEquals($id, $obj->ID, 'ID value has not changed');
+        $this->assertEquals('This has been replaced', $obj->Content);
+    }
 
-	/**
-	 * When a lookup matches more than one page, only the first one should be
-	 * removed.
-	 */
-	public function testMultipleMatchesRemoved() {
-		$obj = $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
-			'Title' => 'Updated',
-			'PopulateMergeAny' => true
-		));
+    /**
+     * When a lookup matches more than one page, only the first one should be
+     * removed.
+     */
+    public function testMultipleMatchesRemoved()
+    {
+        $this->factory->createObject(PopulateFactoryTestObject::class, 'test', array(
+            'Title' => 'Updated',
+            'PopulateMergeAny' => true
+        ));
 
-		$list = PopulateFactoryTestObject::get();
+        $list = PopulateFactoryTestObject::get();
 
-		$this->assertEquals(1, $list->count());
-		$this->assertEquals('Updated', $list->first()->Title);
-	}
-
+        $this->assertEquals(1, $list->count());
+        $this->assertEquals('Updated', $list->first()->Title);
+    }
 }


### PR DESCRIPTION
The functional change is in `PopulateFactory.php` at line `186`. Previously we were using the deprecated `publish()` method. This has been updated to use the `publishSingle()` method by default (keeping backwards compatibility), but I've also added a config `enable_publish_recursive` which devs can opt in to if they prefer.

No functional changes to `Populate.php` or `PopulateFactoryTest.php`. These changes are purely to align them with the project's `.editorconfig`.